### PR TITLE
fix: re-enable the Eth network partitioning test on CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           no_output_timeout: 30m
           command: |
             set -euo pipefail
-            skip_dirs=(".circleci/ .github/ data-package/ ethereum-network-partition-test/")
+            skip_dirs=(".circleci/ .github/ data-package/")
             for directory in */ ; do
               if git --no-pager diff --exit-code origin/main...HEAD -- ':.circleci' ":${directory%/}"; then
                 continue
@@ -73,7 +73,7 @@ jobs:
           no_output_timeout: 30m
           command: |
             set -euo pipefail
-            skip_dirs=(".circleci/ .github/ data-package/ ethereum-network-partition-test/")
+            skip_dirs=(".circleci/ .github/ data-package/")
             for directory in */ ; do
               if ! echo "$skip_dirs" | grep -q "$directory"; then
                 "./${directory}scripts/run.sh"

--- a/ethereum-network-partition-test/eth_starlark_package.star
+++ b/ethereum-network-partition-test/eth_starlark_package.star
@@ -1,4 +1,4 @@
-eth_package = import_module("github.com/kurtosis-tech/eth-network-package/main.star")
+eth_package = import_module("github.com/leoporoli/eth-network-package/main.star")
 
 PARTICIPANT_CONFIG = {
     "el_client_type": "geth",

--- a/ethereum-network-partition-test/eth_starlark_package.star
+++ b/ethereum-network-partition-test/eth_starlark_package.star
@@ -1,4 +1,4 @@
-eth_package = import_module("github.com/leoporoli/eth-network-package/main.star")
+eth_package = import_module("github.com/kurtosis-tech/eth-network-package/main.star")
 
 PARTICIPANT_CONFIG = {
     "el_client_type": "geth",


### PR DESCRIPTION
Right now the `Ethereum network partitioning test` is disabled on CircleCi because this is failing.

You can see the current fails here: https://app.circleci.com/pipelines/github/kurtosis-tech/awesome-kurtosis/693/workflows/dc30cfed-08fc-4306-b313-7a9f9b996c85/jobs/2580 it started in Kurtosis v0.75.9 were we change a piece of code related to the network IP address creations, we are not sure but it seems that this change affected the network partition healing face on this test.

There is an [open PR in the Kurtosis mono repo which reverts the change](https://github.com/kurtosis-tech/kurtosis/pull/585) but we won't' merge this change because it will affect the AutoGPT package that is getting traction now (you can get more context about this modification and why [this affected the AutoGPT package here ](https://kurtosistech.slack.com/archives/C032ZB39AHH/p1682095005129269))

Solution:
1- remove the test because the network partitioning feature is no longer needed and will be deprecated
2- investigate what is the root cause of the problem that affects partition healing, first clue: make sure to check that the partition is merged again by doing some pings from one client to another client in the other subnetwork. Once the problem is found, it should be fixed, and then release a new version of Kurtosis, bump the dependency here, and enable the test again.

More context:
[The discussion about the problem](https://kurtosistech.slack.com/archives/C04HLLL98J2/p1682607217867569)
I created an [Ethereum network package fork](https://github.com/leoporoli/eth-network-package) with a previous version of this package if someone what to import it to test