### PR TITLE
fix: Update package name for `chainlink-node` and `flink-kafka-example` packages

### DIFF
--- a/chainlink-node/kurtosis.yml
+++ b/chainlink-node/kurtosis.yml
@@ -1,1 +1,1 @@
-name: github.com/kurtosis-tech/chainlink-starlark
+name: github.com/kurtosis-tech/awesome-kurtosis/chainlink-node

--- a/chainlink-node/main.star
+++ b/chainlink-node/main.star
@@ -114,8 +114,8 @@ def init_chain_connection(plan, args):
 
 
 def render_chainlink_config(plan, postgres_hostname, postgres_port, chain_name, chain_id, wss_url, http_url):
-    config_file_template = read_file("github.com/kurtosis-tech/chainlink-starlark/chainlink_resources/config.toml.tmpl")
-    secret_file_template = read_file("github.com/kurtosis-tech/chainlink-starlark/chainlink_resources/secret.toml.tmpl")
+    config_file_template = read_file("github.com/kurtosis-tech/awesome-kurtosis/chainlink-node/chainlink_resources/config.toml.tmpl")
+    secret_file_template = read_file("github.com/kurtosis-tech/awesome-kurtosis/chainlink-node/chainlink_resources/secret.toml.tmpl")
     chainlink_config_files = plan.render_templates(
         name="chainlink-configuration",
         config={
@@ -166,7 +166,7 @@ def seed_database(plan, chainlink_config_files):
         )
     )
 
-    seed_user_sql = read_file("github.com/kurtosis-tech/chainlink-starlark/chainlink_resources/seed_users.sql")
+    seed_user_sql = read_file("github.com/kurtosis-tech/awesome-kurtosis/chainlink-node/chainlink_resources/seed_users.sql")
     psql_command = "psql --username {} -c \"{}\" {}".format(POSTGRES_USER, str(seed_user_sql), POSTGRES_DATABASE)
     create_user_recipe = ExecRecipe(command = ["sh", "-c", psql_command])
     plan.wait(

--- a/flink-kafka-example/kurtosis-package/kurtosis.yml
+++ b/flink-kafka-example/kurtosis-package/kurtosis.yml
@@ -1,1 +1,1 @@
-name: "github.com/kurtosis-tech/awesome-kurtosis/flink-kafka-example"
+name: "github.com/kurtosis-tech/awesome-kurtosis/flink-kafka-example/kurtosis-package"


### PR DESCRIPTION
Otherwise they will be ignored by the future version of the indexer