### PR TITLE
fix: wait for next block before checking balance

### DIFF
--- a/smart-contract-example/README.md
+++ b/smart-contract-example/README.md
@@ -33,6 +33,7 @@ This assumes you have the following services installed:
     ```
     This will clone the repository and install all the necessary dependencies.
 
+* NOTE: This example uses the [`eth-network-package`](https://github.com/kurtosis-tech/eth-network-package) which has now been archived. We use it for this example but we recommend using the updated [`ethereum-package`](https://github.com/kurtosis-tech/ethereum-package) for most development purposes.
 2. Now, Run 
     ```
     kurtosis run github.com/kurtosis-tech/eth-network-package

--- a/smart-contract-example/scripts/run.sh
+++ b/smart-contract-example/scripts/run.sh
@@ -6,7 +6,7 @@ package_path="$(dirname "${script_dirpath}")"
 cd $package_path
 
 yarn
-kurtosis run github.com/kurtosis-tech/ethereum-package  --enclave hardhat-enclave '{"network_params": {"capella_fork_epoch": 10}}'
+kurtosis run github.com/kurtosis-tech/eth-network-package  --enclave hardhat-enclave '{"network_params": {"capella_fork_epoch": 10}}'
 
 PORT=$(kurtosis enclave inspect hardhat-enclave | grep "rpc: 8545/tcp" | grep -oh "127.0.0.1\:[0-9]*" | cut -d':' -f2)
 

--- a/smart-contract-example/test/ChipToken.js
+++ b/smart-contract-example/test/ChipToken.js
@@ -2,20 +2,32 @@ const { expect } = require('chai');
 const { ethers } = require('hardhat');
 require("@nomicfoundation/hardhat-chai-matchers");
 
+
 const PLAYER_ONE = '0x878705ba3f8bc32fcf7f4caa1a35e72af65cf766'
 
 describe('ChipToken', function () {
     beforeEach(async function () {
         this.ChipToken = await ethers.getContractFactory("ChipToken");
         this.chips = await this.ChipToken.deploy();
+        await this.chips.deployed();
     });
 
+    // Network needs to bootstrap before running this test successfully needs (~1 min)
     describe("mint", function () {
         it('should mint 1000 chips for PLAYER ONE', async function () {
-            await this.chips.deployed()
             await this.chips.mint(PLAYER_ONE, 1000);
 
-            expect(await this.chips.balanceOf(PLAYER_ONE)).to.equal(1_000);
-        });
+            // Need to wait a slot for this transaction to be posted in the next block
+            // default slot time is 12 seconds, so we wait 13 in case
+            // TODO: Implement a way to mine blocks in eth-network-package instantly to eliminate needing to wait (eg. hardhat 'evm_mine')
+            await sleep(13000);
+
+            const playerOneBalance = await this.chips.balanceOf(PLAYER_ONE)
+            expect(playerOneBalance).to.equal(1_000);
+        }).timeout(1000000);
     });
 });
+
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Addresses https://github.com/kurtosis-tech/awesome-kurtosis/issues/190

Also fixes one of our failing CI tests caused by an update to prefunded keys [here](https://github.com/kurtosis-tech/ethereum-package/commit/743ba44d82e9433e6781e4965ef80bc83e962e25#diff-3a63c8cac63edf32b65f850e8ff239a8b1e1885eef4c1b3fcb7d615768b6b618) by reverting to using the `eth-network-package` for this example.