### PR TITLE
fix test in smart-contract-example

### DIFF
--- a/smart-contract-example/test/ChipToken.js
+++ b/smart-contract-example/test/ChipToken.js
@@ -9,7 +9,7 @@ describe('ChipToken', function () {
     beforeEach(async function () {
         this.ChipToken = await ethers.getContractFactory("ChipToken");
         this.chips = await this.ChipToken.deploy();
-        await this.chips.deployed();
+        await this.chips.waitForDeployment();
     });
 
     // Network needs to bootstrap before running this test successfully needs (~1 min)


### PR DESCRIPTION
Hey,

was trying to follow the  [deploy-and-test-your-dapp-locally](https://docs.kurtosis.com/how-to-local-eth-testnet/#deploy-and-test-your-dapp-locally) 

but when running the `npx hardhat test --network localnet ` i just got following error.

```
  ChipToken
    mint
      1) "before each" hook for "should mint 1000 chips for PLAYER ONE"


  0 passing (66ms)
  1 failing

  1) ChipToken
       "before each" hook for "should mint 1000 chips for PLAYER ONE":
     TypeError: this.chips.deployed is not a function
      at Context.<anonymous> (test/ChipToken.js:11:22)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)

```
`deployed()` is no longer in use and is replaced with `waitForDeployment()`

after changing, the test is passing

```
  ChipToken
    mint
      ✔ should mint 1000 chips for PLAYER ONE (13047ms)


  1 passing (21s)
```